### PR TITLE
fix: binary release run on main branch merge event

### DIFF
--- a/.github/workflows/on_tag_push.yml
+++ b/.github/workflows/on_tag_push.yml
@@ -2,7 +2,6 @@ name: CI/CD
 
 on:
   push:
-    branches: [ main ]
     tags:
       - v*
 


### PR DESCRIPTION
binary release should only be run or triggered by tag push event